### PR TITLE
Simplify ByteString length calculation

### DIFF
--- a/vyper/builtins/_convert.py
+++ b/vyper/builtins/_convert.py
@@ -194,7 +194,7 @@ def _int_to_int(arg, out_typ):
 
 def _check_bytes(expr, arg, output_type, max_bytes_allowed):
     if isinstance(arg.typ, _BytestringT):
-        if arg.typ.maxlen > max_bytes_allowed:
+        if arg.typ.length > max_bytes_allowed:
             _FAIL(arg.typ, output_type, expr)
     else:
         # sanity check. should not have conversions to non-base types
@@ -209,8 +209,8 @@ def _signextend(expr, val, arg_typ):
         assert len(expr.value[2:]) // 2 == arg_typ.m
         n_bits = arg_typ.m_bits
     else:
-        assert len(expr.value) == arg_typ.maxlen
-        n_bits = arg_typ.maxlen * 8
+        assert len(expr.value) == arg_typ.length
+        n_bits = arg_typ.length * 8
 
     return unsigned_to_signed(val, n_bits)
 
@@ -293,7 +293,7 @@ def _to_int(expr, arg, out_typ):
     elif isinstance(arg.typ, BytesT):
         arg_typ = arg.typ
         arg = _bytes_to_num(arg, out_typ, signed=out_typ.is_signed)
-        if arg_typ.maxlen * 8 > out_typ.bits:
+        if arg_typ.length * 8 > out_typ.bits:
             arg = int_clamp(arg, out_typ.bits, signed=out_typ.is_signed)
 
     elif is_bytes_m_type(arg.typ):
@@ -336,7 +336,7 @@ def to_decimal(expr, arg, out_typ):
     if isinstance(arg.typ, BytesT):
         arg_typ = arg.typ
         arg = _bytes_to_num(arg, out_typ, signed=True)
-        if arg_typ.maxlen * 8 > 168:
+        if arg_typ.length * 8 > 168:
             arg = IRnode.from_list(arg, typ=out_typ)
             arg = clamp_basetype(arg)
 
@@ -425,7 +425,7 @@ def to_address(expr, arg, out_typ):
 # question: should we allow bytesM -> String?
 @_input_types(BytesT)
 def to_string(expr, arg, out_typ):
-    _check_bytes(expr, arg, out_typ, out_typ.maxlen)
+    _check_bytes(expr, arg, out_typ, out_typ.length)
 
     # NOTE: this is a pointer cast
     return IRnode.from_list(arg, typ=out_typ)
@@ -433,7 +433,7 @@ def to_string(expr, arg, out_typ):
 
 @_input_types(StringT)
 def to_bytes(expr, arg, out_typ):
-    _check_bytes(expr, arg, out_typ, out_typ.maxlen)
+    _check_bytes(expr, arg, out_typ, out_typ.length)
 
     # TODO: more casts
 

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -2398,12 +2398,12 @@ class ABIEncode(BuiltinFunctionT):
         else:
             arg_abi_t = ABI_Tuple(arg_abi_types)
 
-        max_length = arg_abi_t.size_bound()
+        length = arg_abi_t.size_bound()
         if has_method_id:
             # the output includes 4 bytes for the method_id.
-            max_length += 4
+            length += 4
 
-        return BytesT(max_length)
+        return BytesT(length)
 
     @staticmethod
     def _parse_method_id(method_id_literal):

--- a/vyper/builtins/functions.py
+++ b/vyper/builtins/functions.py
@@ -296,11 +296,6 @@ class Slice(BuiltinFunctionT):
     def fetch_call_return(self, node):
         arg_type, _, _ = self.infer_arg_types(node)
 
-        if isinstance(arg_type, StringT):
-            return_type = StringT()
-        else:
-            return_type = BytesT()
-
         # validate start and length are in bounds
 
         arg = node.args[0]
@@ -329,13 +324,10 @@ class Slice(BuiltinFunctionT):
                 if length_literal is not None and start_literal + length_literal > arg_type.length:
                     raise ArgumentException(f"slice out of bounds for {arg_type}", node)
 
-        # we know the length statically
-        if length_literal is not None:
-            return_type.set_length(length_literal)
-        else:
-            return_type.set_min_length(arg_type.length)
-
-        return return_type
+        return_type = StringT if isinstance(arg_type, StringT) else BytesT
+        if length_literal is None:
+            return return_type(min_length=arg_type.length)
+        return return_type(length_literal)
 
     def infer_arg_types(self, node):
         self._validate_arg_types(node)
@@ -497,12 +489,8 @@ class Concat(BuiltinFunctionT):
         for arg_t in arg_types:
             length += arg_t.length
 
-        if isinstance(arg_types[0], (StringT)):
-            return_type = StringT()
-        else:
-            return_type = BytesT()
-        return_type.set_length(length)
-        return return_type
+        return_type = StringT if isinstance(arg_types[0], StringT) else BytesT
+        return return_type(length)
 
     def infer_arg_types(self, node):
         if len(node.args) < 2:
@@ -1086,8 +1074,7 @@ class RawCall(BuiltinFunctionT):
             raise
 
         if outsize.value:
-            return_type = BytesT()
-            return_type.set_min_length(outsize.value)
+            return_type = BytesT(min_length=outsize.value)
 
             if revert_on_failure:
                 return return_type
@@ -2415,15 +2402,12 @@ class ABIEncode(BuiltinFunctionT):
         else:
             arg_abi_t = ABI_Tuple(arg_abi_types)
 
-        maxlen = arg_abi_t.size_bound()
-
+        max_length = arg_abi_t.size_bound()
         if has_method_id:
             # the output includes 4 bytes for the method_id.
-            maxlen += 4
+            max_length += 4
 
-        ret = BytesT()
-        ret.set_length(maxlen)
-        return ret
+        return BytesT(max_length)
 
     @staticmethod
     def _parse_method_id(method_id_literal):

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -858,14 +858,7 @@ def make_setter(left, right):
     # Byte arrays
     elif isinstance(left.typ, _BytestringT):
         # TODO rethink/streamline the clamp_basetype logic
-        if left.typ.length and not right.typ.length:
-            # right side has unknown size, check it during runtime
-            with right.cache_when_complex("bs_ptr") as (b, right):
-                clamped = clamp("le", get_bytearray_length(right), left.typ.length)
-                copier = make_byte_array_copier(left, right)
-                ret = b.resolve(["seq", clamped, copier])
-
-        elif needs_clamp(right.typ, right.encoding):
+        if needs_clamp(right.typ, right.encoding):
             with right.cache_when_complex("bs_ptr") as (b, right):
                 copier = make_byte_array_copier(left, right)
                 ret = b.resolve(["seq", clamp_bytestring(right), copier])

--- a/vyper/codegen/core.py
+++ b/vyper/codegen/core.py
@@ -858,7 +858,14 @@ def make_setter(left, right):
     # Byte arrays
     elif isinstance(left.typ, _BytestringT):
         # TODO rethink/streamline the clamp_basetype logic
-        if needs_clamp(right.typ, right.encoding):
+        if left.typ.length and not right.typ.length:
+            # right side has unknown size, check it during runtime
+            with right.cache_when_complex("bs_ptr") as (b, right):
+                clamped = clamp("le", get_bytearray_length(right), left.typ.length)
+                copier = make_byte_array_copier(left, right)
+                ret = b.resolve(["seq", clamped, copier])
+
+        elif needs_clamp(right.typ, right.encoding):
             with right.cache_when_complex("bs_ptr") as (b, right):
                 copier = make_byte_array_copier(left, right)
                 ret = b.resolve(["seq", clamp_bytestring(right), copier])

--- a/vyper/codegen/keccak256_helper.py
+++ b/vyper/codegen/keccak256_helper.py
@@ -49,6 +49,6 @@ def keccak256_helper(to_hash, context):
                 ["sha3", data, len_],
                 typ=BYTES32_T,
                 annotation="keccak256",
-                add_gas_estimate=_gas_bound(ceil(to_hash.typ.maxlen / 32)),
+                add_gas_estimate=_gas_bound(ceil(to_hash.typ.length / 32)),
             )
         )

--- a/vyper/semantics/analysis/local.py
+++ b/vyper/semantics/analysis/local.py
@@ -647,6 +647,7 @@ class _ExprVisitor(VyperNodeVisitorBase):
 
     def visit_Call(self, node: vy_ast.Call, typ: VyperType) -> None:
         call_type = get_exact_type_from_node(node.func)
+
         # except for builtin functions, `get_exact_type_from_node`
         # already calls `validate_expected_type` on the call args
         # and kwargs via `call_type.fetch_call_return`
@@ -656,6 +657,9 @@ class _ExprVisitor(VyperNodeVisitorBase):
             # function calls
             if call_type.is_internal:
                 self.func.called_functions.add(call_type)
+            if isinstance(call_type.return_type, _BytestringT) and not call_type.return_type.length:
+                # return type is a bytestring with unknown length: use the type of the expression
+                call_type.return_type = typ
             for arg, typ in zip(node.args, call_type.argument_types):
                 self.visit(arg, typ)
             for kwarg in node.keywords:

--- a/vyper/semantics/analysis/utils.py
+++ b/vyper/semantics/analysis/utils.py
@@ -160,7 +160,7 @@ class _ExprAnalyser:
                     raise InvalidReference(f"not a variable or literal: '{invalid.typedef}'", node)
 
             if all(isinstance(i, IntegerT) for i in ret):
-                # for numeric types, sort according by number of bits descending
+                # for numeric types, sort according to number of bits descending
                 # this ensures literals are cast with the largest possible type
                 ret.sort(key=lambda k: (k.bits, not k.is_signed), reverse=True)
 

--- a/vyper/semantics/types/bytestrings.py
+++ b/vyper/semantics/types/bytestrings.py
@@ -20,24 +20,19 @@ class _BytestringT(VyperType):
     Attributes
     ----------
     _length : int
-        The maximum allowable length of the data within the type.
-    _min_length: int
-        The minimum length of the data within the type. Used when the type
-        is applied to a literal definition.
+        The allowable length of the data within the type.
     """
 
     # this is a carveout because currently we allow dynamic arrays of
     # bytestrings, but not static arrays of bytestrings
     _as_darray = True
     _as_hashmap_key = True
-    _equality_attrs = ("_length", "_min_length")
+    _equality_attrs = "_length",
     _is_bytestring: bool = True
 
-    def __init__(self, length: int = 0, min_length: int = 0) -> None:
+    def __init__(self, length: int = 0) -> None:
         super().__init__()
-
         self._length = length
-        self._min_length = min_length or length
 
     def __repr__(self):
         return f"{self._id}[{self.length}]"
@@ -47,16 +42,7 @@ class _BytestringT(VyperType):
         """
         Property method used to check the length of a type.
         """
-        if self._length:
-            return self._length
-        return self._min_length
-
-    @property
-    def maxlen(self):
-        """
-        Alias for backwards compatibility.
-        """
-        return self.length
+        return self._length
 
     def validate_literal(self, node: vy_ast.Constant) -> None:
         super().validate_literal(node)
@@ -97,17 +83,16 @@ class _BytestringT(VyperType):
 
         if length is None:
             raise StructureException(
-                f"Cannot declare {cls._id} type without a maximum length, e.g. {cls._id}[5]", node
+                f"Cannot declare {cls._id} type without a length, e.g. {cls._id}[5]", node
             )
 
-        length = length or 0
-        return cls(length, min_length=length)
+        return cls(length)
 
     @classmethod
     def from_literal(cls, node: vy_ast.Constant) -> "_BytestringT":
         if not isinstance(node, cls._valid_literal):
             raise UnexpectedNodeType(f"Not a {cls._id}: {node}")
-        return cls(min_length=len(node.value))
+        return cls(length=len(node.value))
 
 
 class BytesT(_BytestringT):


### PR DESCRIPTION
### What I did
Get rid of side effect comparing byte string sizes

### How I did it
- Remove `set` methods from `_BytestringT`
- Always pass size to constructor when available
- Check the return type of method calls
- Remove existing min/max length

### How to verify it
- Run the test `tests/functional/codegen/test_interfaces.py::test_json_abi_bytes_clampers`

### Commit message
Get rid of side effect comparing byte string sizes

### Description for the changelog
n/a

### Cute Animal Picture

![image](https://github.com/charles-cooper/vyper/assets/2369243/a4907c4b-7399-49ab-9bf6-46b865915815)
