### PR TITLE
tests: await

### DIFF
--- a/examples/factory/Exchange.vy
+++ b/examples/factory/Exchange.vy
@@ -20,7 +20,7 @@ def __init__(_token: IERC20, _factory: Factory):
 @external
 def initialize():
     # Anyone can safely call this function because of EXTCODEHASH
-    self.factory.register()
+    extcall self.factory.register()
 
 
 # NOTE: This contract restricts trading to only be done by the factory.
@@ -31,12 +31,12 @@ def initialize():
 @external
 def receive(_from: address, _amt: uint256):
     assert msg.sender == self.factory.address
-    success: bool = self.token.transferFrom(_from, self, _amt)
+    success: bool = extcall self.token.transferFrom(_from, self, _amt)
     assert success
 
 
 @external
 def transfer(_to: address, _amt: uint256):
     assert msg.sender == self.factory.address
-    success: bool = self.token.transfer(_to, _amt)
+    success: bool = extcall self.token.transfer(_to, _amt)
     assert success

--- a/examples/factory/Factory.vy
+++ b/examples/factory/Factory.vy
@@ -35,12 +35,12 @@ def register():
     # NOTE: Should do checks that it hasn't already been set,
     #       which has to be rectified with any upgrade strategy.
     exchange: Exchange = Exchange(msg.sender)
-    self.exchanges[exchange.token()] = exchange
+    self.exchanges[staticcall exchange.token()] = exchange
 
 
 @external
 def trade(_token1: IERC20, _token2: IERC20, _amt: uint256):
     # Perform a straight exchange of token1 to token 2 (1:1 price)
     # NOTE: Any practical implementation would need to solve the price oracle problem
-    self.exchanges[_token1].receive(msg.sender, _amt)
-    self.exchanges[_token2].transfer(msg.sender, _amt)
+    extcall self.exchanges[_token1].receive(msg.sender, _amt)
+    extcall self.exchanges[_token2].transfer(msg.sender, _amt)

--- a/examples/tokens/ERC721.vy
+++ b/examples/tokens/ERC721.vy
@@ -248,7 +248,7 @@ def safeTransferFrom(
     """
     self._transferFrom(_from, _to, _tokenId, msg.sender)
     if _to.is_contract: # check if `_to` is a contract address
-        returnValue: bytes4 = ERC721Receiver(_to).onERC721Received(msg.sender, _from, _tokenId, _data)
+        returnValue: bytes4 = extcall ERC721Receiver(_to).onERC721Received(msg.sender, _from, _tokenId, _data)
         # Throws if transfer destination is a contract which does not implement 'onERC721Received'
         assert returnValue == method_id("onERC721Received(address,address,uint256,bytes)", output_type=bytes4)
 

--- a/tests/functional/codegen/calling_convention/test_external_contract_calls.py
+++ b/tests/functional/codegen/calling_convention/test_external_contract_calls.py
@@ -1522,7 +1522,7 @@ interface Bar:
 
 @external
 def foo(a: address):
-    staticcall Bar(a).bar(1)
+    a: bool = staticcall Bar(a).bar(1)
     """,
     """
 interface Bar:

--- a/tests/functional/codegen/calling_convention/test_return.py
+++ b/tests/functional/codegen/calling_convention/test_return.py
@@ -613,7 +613,7 @@ def foo(addr: address) -> Foo:
     return Foo(
         a=1,
         b=2,
-        c=IBar(addr).bar().a,
+        c=(staticcall IBar(addr).bar()).a,
         d=4,
         e=5
     )
@@ -693,7 +693,7 @@ def foo(addr: address) -> Foo:
         b=2,
         c=(staticcall IBar(addr).bar()).a,
         d=4,
-        e=(staticcall IBar(addr).baz(IBar(addr).bar()).b)
+        e=(staticcall IBar(addr).baz(staticcall IBar(addr).bar())).b
     )
     """
 
@@ -732,7 +732,7 @@ interface IBar:
 @external
 def foo(addr: address) -> Foo:
     return Foo(
-        a=staticcall IBar(addr).baz(IBar(addr).bar()).a
+        a=(staticcall IBar(addr).baz(staticcall IBar(addr).bar())).a
     )
     """
 

--- a/tests/functional/codegen/types/test_string.py
+++ b/tests/functional/codegen/types/test_string.py
@@ -145,7 +145,7 @@ def test(addr: address) -> (int128, address, String[10]):
     a: int128 = 0
     b: address = empty(address)
     c: String[10] = ""
-    (a, b, c) = Test(addr).out_literals()
+    (a, b, c) = staticcall Test(addr).out_literals()
     return a, b,c
     """
     c1 = get_contract_with_gas_estimation(contract_1)

--- a/tests/functional/syntax/exceptions/test_constancy_exception.py
+++ b/tests/functional/syntax/exceptions/test_constancy_exception.py
@@ -83,37 +83,31 @@ def b():
         """
 interface A:
     def bar() -> uint16: view
+
 @external
 @pure
-def test(to:address):
-    a:A = A(to)
-    x:uint16 = a.bar()
-    """,
-        """
-interface A:
-    def bar() -> uint16: view
-@external
-@pure
-def test(to:address):
-    a:A = A(to)
-    a.bar()
+def test(to: address):
+    a: A = A(to)
+    x: uint16 = staticcall a.bar()
     """,
         """
 interface A:
     def bar() -> uint16: nonpayable
+
 @external
 @view
-def test(to:address):
-    a:A = A(to)
-    x:uint16 = a.bar()
+def test(to: address):
+    a: A = A(to)
+    x: uint16 = extcall a.bar()
     """,
         """
 interface A:
     def bar() -> uint16: nonpayable
+
 @external
 @view
-def test(to:address):
-    a:A = A(to)
+def test(to: address):
+    a: A = A(to)
     a.bar()
     """,
         """

--- a/tests/functional/syntax/modules/test_initializers.py
+++ b/tests/functional/syntax/modules/test_initializers.py
@@ -594,7 +594,7 @@ something: uint256
 
 @internal
 def foo() -> uint256:
-    lib1.counter[1][2], self.something = Foo(msg.sender).foo()
+    lib1.counter[1][2], self.something = extcall Foo(msg.sender).foo()
     """
     main = """
 import lib1
@@ -630,7 +630,7 @@ interface Foo:
 
 @internal
 def write_tuple():
-    self.counter[1][2], self.something = Foo(msg.sender).foo()
+    self.counter[1][2], self.something = extcall Foo(msg.sender).foo()
     """
     lib2 = """
 import lib1

--- a/tests/functional/syntax/test_address_code.py
+++ b/tests/functional/syntax/test_address_code.py
@@ -153,7 +153,7 @@ interface Test:
 
 @external
 def foo(x: address) -> Bytes[4]:
-    return slice(Test(x).out_literals().code, 0, 4)
+    return slice((staticcall Test(x).out_literals()).code, 0, 4)
 """,
     ],
 )

--- a/tests/functional/syntax/test_for_range.py
+++ b/tests/functional/syntax/test_for_range.py
@@ -386,7 +386,7 @@ foos: Foo[3]
 @external
 def kick_foos():
     for foo: Foo in self.foos:
-        foo.kick()
+        extcall foo.kick()
     """,
 ]
 

--- a/tests/functional/syntax/test_interfaces.py
+++ b/tests/functional/syntax/test_interfaces.py
@@ -230,7 +230,7 @@ from ethereum.ercs import IERC20
 b: IERC20
 @external
 def test(input: address):
-    assert self.b.totalSupply() == IERC20(input).totalSupply()
+    assert staticcall self.b.totalSupply() == staticcall IERC20(input).totalSupply()
     """,
     """
 from ethereum.ercs import IERC20
@@ -243,10 +243,10 @@ token: IERC20
 
 @external
 def test():
-    assert self.factory.getExchange(self.token.address) == self
-    exchange: address = self.factory.getExchange(self.token.address)
+    assert staticcall self.factory.getExchange(self.token.address) == self
+    exchange: address = staticcall self.factory.getExchange(self.token.address)
     assert exchange == self.token.address
-    assert self.token.totalSupply() > 0
+    assert staticcall self.token.totalSupply() > 0
     """,
     """
 interface Foo:
@@ -326,7 +326,7 @@ interface Foo:
 @external
 def bar(x: address):
     a: Foo = Foo(x)
-    a.append(1)
+    extcall a.append(1)
     """,
     """
 interface Foo:
@@ -335,7 +335,7 @@ interface Foo:
 @external
 def foo(x: address):
     a: Foo = Foo(x)
-    a.pop()
+    extcall a.pop()
     """,
     """
 interface ITestInterface:

--- a/tests/functional/syntax/test_return_tuple.py
+++ b/tests/functional/syntax/test_return_tuple.py
@@ -103,7 +103,7 @@ interface Foo:
 
 @external
 def foo(a: address) -> (uint256, uint256, uint256, uint256, uint256):
-    return 1, 2, Foo(a).foo()[0], 4, 5
+    return 1, 2, (staticcall Foo(a).foo())[0], 4, 5
     """
 
     c = get_contract(code)
@@ -132,7 +132,7 @@ interface Foo:
 
 @external
 def foo(a: address) -> (uint256, uint256, uint256, uint256, uint256):
-    return 1, 2, Foo(a).foo()[0], 4, Foo(a).bar(Foo(a).foo()[1])
+    return 1, 2, (staticcall Foo(a).foo())[0], 4, staticcall Foo(a).bar((staticcall Foo(a).foo())[1])
     """
 
     c = get_contract(code)

--- a/tests/unit/cli/vyper_compile/test_compile_files.py
+++ b/tests/unit/cli/vyper_compile/test_compile_files.py
@@ -42,7 +42,7 @@ def foo() -> {alias}.FooStruct:
 
 @external
 def bar(a: address) -> {alias}.FooStruct:
-    return {alias}(a).bar()
+    return extcall {alias}(a).bar()
 """
 
 INTERFACE_CODE = """
@@ -172,7 +172,7 @@ def be_known() -> FooStruct:
 
 @external
 def know_thyself(a: address) -> ISelf.FooStruct:
-    return ISelf(a).be_known()
+    return extcall ISelf(a).be_known()
 
 @external
 def be_known() -> ISelf.FooStruct:
@@ -192,11 +192,11 @@ def test_another_interface_implementation(import_stmt_foo, alias, tmp_path, make
 
 @external
 def foo(a: address) -> {alias}.FooStruct:
-    return {alias}(a).foo()
+    return extcall {alias}(a).foo()
 
 @external
 def bar(_foo: address) -> {alias}.FooStruct:
-    return {alias}(_foo).bar()
+    return extcall {alias}(_foo).bar()
     """
     make_file("contracts/IFoo.vyi", INTERFACE_CODE)
     baz = make_file("contracts/Baz.vy", baz_code)

--- a/tests/unit/cli/vyper_json/test_compile_json.py
+++ b/tests/unit/cli/vyper_json/test_compile_json.py
@@ -21,7 +21,7 @@ import contracts.library as library
 
 @external
 def foo(a: address) -> bool:
-    return IBar(a).bar(1)
+    return extcall IBar(a).bar(1)
 
 @external
 def baz() -> uint256:

--- a/tests/unit/cli/vyper_json/test_parse_args_vyperjson.py
+++ b/tests/unit/cli/vyper_json/test_parse_args_vyperjson.py
@@ -13,7 +13,7 @@ import contracts.ibar as IBar
 
 @external
 def foo(a: address) -> bool:
-    return IBar(a).bar(1)
+    return extcall IBar(a).bar(1)
 """
 
 BAR_CODE = """

--- a/tests/unit/compiler/test_abi.py
+++ b/tests/unit/compiler/test_abi.py
@@ -489,7 +489,7 @@ import ifoo
 
 @external
 def bar():
-    ifoo(msg.sender).foo()
+    extcall ifoo(msg.sender).foo()
     """
     input_bundle = make_input_bundle({"ifoo.vyi": ifoo})
     out = compile_code(main, input_bundle=input_bundle, output_formats=["abi"])

--- a/tests/unit/compiler/test_pre_parser.py
+++ b/tests/unit/compiler/test_pre_parser.py
@@ -49,7 +49,7 @@ bar_contract: Bar
 @external
 def foo(contract_address: address) -> int128:
     self.bar_contract = Bar(contract_address)
-    return self.bar_contract.bar()
+    return extcall self.bar_contract.bar()
     """
 
     c1 = get_contract(contract_1)


### PR DESCRIPTION
Added some tests for await. There is still a failing grammar check for examples like `(staticcall IBar(address).foo())[0]`.