### PR TITLE
more tests for await

### DIFF
--- a/examples/market_maker/on_chain_market_maker.vy
+++ b/examples/market_maker/on_chain_market_maker.vy
@@ -8,7 +8,7 @@ totalTokenQty: public(uint256)
 # Constant set in `initiate` that's used to calculate
 # the amount of ether/tokens that are exchanged
 invariant: public(uint256)
-token_address: IERC20
+token: IERC20
 owner: public(address)
 
 # Sets the on chain market maker with its owner, initial token quantity,
@@ -17,8 +17,8 @@ owner: public(address)
 @payable
 def initiate(token_addr: address, token_quantity: uint256):
     assert self.invariant == 0
-    self.token_address = IERC20(token_addr)
-    self.token_address.transferFrom(msg.sender, self, token_quantity)
+    self.token = IERC20(token_addr)
+    extcall self.token.transferFrom(msg.sender, self, token_quantity)
     self.owner = msg.sender
     self.totalEthQty = msg.value
     self.totalTokenQty = token_quantity
@@ -33,14 +33,14 @@ def ethToTokens():
     eth_in_purchase: uint256 = msg.value - fee
     new_total_eth: uint256 = self.totalEthQty + eth_in_purchase
     new_total_tokens: uint256 = self.invariant // new_total_eth
-    self.token_address.transfer(msg.sender, self.totalTokenQty - new_total_tokens)
+    extcall self.token.transfer(msg.sender, self.totalTokenQty - new_total_tokens)
     self.totalEthQty = new_total_eth
     self.totalTokenQty = new_total_tokens
 
 # Sells tokens to the contract in exchange for ether
 @external
 def tokensToEth(sell_quantity: uint256):
-    self.token_address.transferFrom(msg.sender, self, sell_quantity)
+    extcall self.token.transferFrom(msg.sender, self, sell_quantity)
     new_total_tokens: uint256 = self.totalTokenQty + sell_quantity
     new_total_eth: uint256 = self.invariant // new_total_tokens
     eth_to_send: uint256 = self.totalEthQty - new_total_eth
@@ -52,5 +52,5 @@ def tokensToEth(sell_quantity: uint256):
 @external
 def ownerWithdraw():
     assert self.owner == msg.sender
-    self.token_address.transfer(self.owner, self.totalTokenQty)
+    extcall self.token.transfer(self.owner, self.totalTokenQty)
     selfdestruct(self.owner)

--- a/tests/functional/codegen/calling_convention/test_external_contract_calls.py
+++ b/tests/functional/codegen/calling_convention/test_external_contract_calls.py
@@ -129,11 +129,11 @@ def run():
     """
     caller = """
 interface Raises:
-    def run(): pure
+    def run(): nonpayable
 
 @external
 def run(raiser: address):
-    staticcall Raises(raiser).run()
+    extcall Raises(raiser).run()
     """
     c1 = get_contract(raiser)
     c2 = get_contract(caller)

--- a/tests/functional/codegen/calling_convention/test_modifiable_external_contract_calls.py
+++ b/tests/functional/codegen/calling_convention/test_modifiable_external_contract_calls.py
@@ -34,7 +34,7 @@ def modifiable_set_lucky(_lucky: int128):
 
 @external
 def static_set_lucky(_lucky: int128):
-    staticcall self.static_bar_contract.set_lucky(_lucky)
+    extcall self.static_bar_contract.set_lucky(_lucky)
     """
 
     c1 = get_contract(contract_1)

--- a/tests/functional/codegen/calling_convention/test_return.py
+++ b/tests/functional/codegen/calling_convention/test_return.py
@@ -693,7 +693,7 @@ def foo(addr: address) -> Foo:
         b=2,
         c=(staticcall IBar(addr).bar()).a,
         d=4,
-        e=(staticcall IBar(addr).baz(staticcall IBar(addr).bar())).b
+        e=(staticcall IBar(addr).baz((staticcall IBar(addr).bar()).b))
     )
     """
 
@@ -732,7 +732,7 @@ interface IBar:
 @external
 def foo(addr: address) -> Foo:
     return Foo(
-        a=(staticcall IBar(addr).baz(staticcall IBar(addr).bar())).a
+        a=staticcall IBar(addr).baz((staticcall IBar(addr).bar()).a)
     )
     """
 

--- a/tests/functional/codegen/modules/test_exports.py
+++ b/tests/functional/codegen/modules/test_exports.py
@@ -102,7 +102,7 @@ interface Foo:
 
 @external
 def call_bar(foo: Foo) -> uint256:
-    return foo.bar()
+    return extcall foo.bar()
     """
     input_bundle = make_input_bundle({"lib1.vy": lib1})
     c = get_contract(main, input_bundle=input_bundle)

--- a/tests/functional/codegen/modules/test_interface_imports.py
+++ b/tests/functional/codegen/modules/test_interface_imports.py
@@ -19,7 +19,7 @@ import ifaces
 
 @external
 def test_foo(s: ifaces.IFoo) -> bool:
-    assert s.foo() == block.number
+    assert extcall s.foo() == block.number
     return True
     """
 

--- a/tests/functional/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/functional/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -126,19 +126,19 @@ def __init__(_purchase_contract: address):
 @payable
 @external
 def start_purchase():
-    self.purchase_contract.purchase(value=2)
+    extcall self.purchase_contract.purchase(value=2)
 
 
 @payable
 @external
 def start_received():
-    self.purchase_contract.received()
+   extcall self.purchase_contract.received()
 
 
 @external
 @payable
 def __default__():
-    self.purchase_contract.received()
+    extcall self.purchase_contract.received()
 
     """
 

--- a/tests/functional/syntax/exceptions/test_constancy_exception.py
+++ b/tests/functional/syntax/exceptions/test_constancy_exception.py
@@ -108,7 +108,7 @@ interface A:
 @view
 def test(to: address):
     a: A = A(to)
-    a.bar()
+    extcall a.bar()
     """,
         """
 a:DynArray[uint16,3]
@@ -129,7 +129,7 @@ token: IERC20
 @external
 @view
 def topup(amount: uint256):
-    assert self.token.transferFrom(msg.sender, self, amount)
+    assert extcall self.token.transferFrom(msg.sender, self, amount)
     """,
     ],
 )

--- a/tests/functional/syntax/test_functions_call.py
+++ b/tests/functional/syntax/test_functions_call.py
@@ -63,7 +63,7 @@ factory: Factory
 @external
 def setup(token_addr: address):
     self.token = IERC20(token_addr)
-    assert self.factory.getExchange(self.token.address) == self
+    assert staticcall self.factory.getExchange(self.token.address) == self
     """,
 ]
 


### PR DESCRIPTION
There are a couple of outstanding failing tests involving view functions without a return value that will now be blocked because they require `staticcall` but at the same time has no return value.